### PR TITLE
chore(deps): bump h11 from 0.14.0 to 0.16.0 in the pip group

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -55,7 +55,7 @@ google-auth-oauthlib==1.2.1
 googleapis-common-protos==1.63.2
 gradio_client==1.3.0
 greenlet==3.0.3
-h11==0.14.0
+h11==0.16.0
 httpcore==1.0.7
 httplib2==0.22.0
 httpx==0.28.1


### PR DESCRIPTION
Bumps the pip group with 1 update: [h11](https://github.com/python-hyper/h11).


Updates `h11` from 0.14.0 to 0.16.0
- [Commits](https://github.com/python-hyper/h11/compare/v0.14.0...v0.16.0)

---
updated-dependencies:
- dependency-name: h11 dependency-version: 0.16.0 dependency-type: direct:production dependency-group: pip ...

## Summary by Sourcery

Chores:
- Bump h11 from 0.14.0 to 0.16.0.