### PR TITLE
Potential fix for code scanning alert no. 52: Server-side request forgery

### DIFF
--- a/staticfiles/journal/scripts/proxy-server.js
+++ b/staticfiles/journal/scripts/proxy-server.js
@@ -31,7 +31,10 @@ app.get('/proxy', (req, res) => {
     }
 
     // Prevent path traversal
-    const sanitizedPath = parsedUrl.pathname.replace(/(\.\.[/\\])/g, '');
+    let sanitizedPath = parsedUrl.pathname;
+    do {
+        sanitizedPath = sanitizedPath.replace(/(\.\.[/\\])/g, '');
+    } while (sanitizedPath.includes('..'));
     const finalUrl = new URL(sanitizedPath + parsedUrl.search, baseUrl);
 
     request({ url: finalUrl.toString(), method: 'GET' }).pipe(res);


### PR DESCRIPTION
Potential fix for [https://github.com/Carnage-Joker/pink_book/security/code-scanning/52](https://github.com/Carnage-Joker/pink_book/security/code-scanning/52)

To fix the SSRF vulnerability, we need to enhance the validation of the user-provided URL. Specifically:
1. Use a stricter validation mechanism to ensure that the hostname matches the allowlist exactly and cannot be bypassed using subdomains, URL encoding, or other techniques.
2. Avoid directly passing the user-provided URL to the `request` library. Instead, construct the URL using a predefined base URL and controlled path segments.

The fix involves:
- Parsing the user-provided URL and extracting only the pathname and query string.
- Constructing the final URL using a predefined base URL from the allowlist.
- Rejecting any input that attempts to perform path traversal (e.g., `../`).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Tighten URL validation in the proxy endpoint to prevent SSRF by enforcing an exact domain allowlist, constructing requests from predefined base URLs, and sanitizing path traversal.

Bug Fixes:
- Reject requests for hostnames not present in the allowlist instead of using a simple array include check
- Return a 400 status for invalid URLs

Enhancements:
- Replace the allowlist array with a hostname-to-base-URL map to ensure exact matching
- Sanitize pathnames to remove path traversal segments before constructing the final URL
- Build the outgoing request URL using the predefined base URL combined with sanitized path and query components