### PR TITLE
Potential fix for code scanning alert no. 54: Information exposure through an exception

### DIFF
--- a/journal/views.py
+++ b/journal/views.py
@@ -865,7 +865,7 @@ class FailTaskView(View):
             )
         except Exception as e:
             logger.error(f"Error processing task failure: {str(e)}")
-            return JsonResponse({"status": "error", "message": str(e)}, status=500)
+            return JsonResponse({"status": "error", "message": "An internal error occurred."}, status=500)
 
 # Forum and Blog Views
 class BlogListView(ListView):


### PR DESCRIPTION
Potential fix for [https://github.com/Carnage-Joker/pink_book/security/code-scanning/54](https://github.com/Carnage-Joker/pink_book/security/code-scanning/54)

To fix the issue, we will replace the exposed exception message (`str(e)`) in the JSON response with a generic error message, such as "An internal error occurred." This ensures that sensitive information is not leaked to the user. At the same time, the detailed exception message will still be logged using the `logger.error` call, preserving the ability to debug issues internally.

The changes will be made in the `post` method of the `FailTaskView` class in `journal/views.py`. Specifically:
1. Replace the `str(e)` in the JSON response on line 868 with a generic error message.
2. Ensure that the `logger.error` call on line 867 remains unchanged to log the detailed exception for internal debugging.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Use a generic error message in the JSON response to prevent information leakage while still logging the detailed exception internally for debugging.

Bug Fixes:
- Mask exception details in the API error response to avoid exposing sensitive information.

Enhancements:
- Preserve detailed exception logging via logger.error for internal debugging.