### PR TITLE
Potential fix for code scanning alert no. 8: Unsafe expansion of self-closing HTML tag

### DIFF
--- a/staticfiles/journal/scripts/jquery-1.10.2.js
+++ b/staticfiles/journal/scripts/jquery-1.10.2.js
@@ -6580,7 +6580,11 @@ jQuery.extend({
 					tag = ( rtagName.exec( elem ) || ["", ""] )[1].toLowerCase();
 					wrap = wrapMap[ tag ] || wrapMap._default;
 
-					tmp.innerHTML = wrap[1] + elem.replace( rxhtmlTag, "<$1></$2>" ) + wrap[2];
+					var tempDiv = document.createElement("div");
+					tempDiv.innerHTML = wrap[1] + elem + wrap[2];
+					while (tempDiv.firstChild) {
+						tmp.appendChild(tempDiv.firstChild);
+					}
 
 					// Descend through wrappers to the right content
 					j = wrap[0];


### PR DESCRIPTION
Potential fix for [https://github.com/Carnage-Joker/pink_book/security/code-scanning/8](https://github.com/Carnage-Joker/pink_book/security/code-scanning/8)

To fix the issue, we need to ensure that the transformation of self-closing tags does not invalidate prior sanitization or introduce vulnerabilities. Instead of directly modifying the HTML string using a regular expression, we should use a safer approach, such as leveraging a DOM parser to handle the transformation. This avoids the pitfalls of regular expressions and ensures that the resulting HTML is well-formed.

The fix involves replacing the use of `elem.replace(rxhtmlTag, "<$1></$2>")` with a DOM-based approach. Specifically, we can create a temporary DOM element, set its `innerHTML` to the sanitized input, and then extract the resulting nodes. This ensures that the browser's HTML parser handles the transformation safely.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Use a DOM-based approach to expand self-closing HTML tags in jQuery safely, replacing the unsafe regex-based transformation.

Bug Fixes:
- Fix code scanning alert #8 by avoiding unsafe regex expansion of self-closing HTML tags.

Enhancements:
- Replace `elem.replace(rxhtmlTag,…)` with a temporary div’s `innerHTML` and node reparenting to ensure well-formed HTML.