### PR TITLE
Potential fix for code scanning alert no. 5: Unsafe expansion of self-closing HTML tag

### DIFF
--- a/static/journal/scripts/jquery-1.10.2.js
+++ b/static/journal/scripts/jquery-1.10.2.js
@@ -6166,7 +6166,23 @@ jQuery.fn.extend({
 				( jQuery.support.leadingWhitespace || !rleadingWhitespace.test( value ) ) &&
 				!wrapMap[ ( rtagName.exec( value ) || ["", ""] )[1].toLowerCase() ] ) {
 
-				value = value.replace( rxhtmlTag, "<$1></$2>" );
+				// Use a DOM parser to safely expand self-closing tags
+				var parser = new DOMParser();
+				var doc = parser.parseFromString(value, "text/html");
+				var elements = doc.body.children;
+
+				for (var j = 0; j < elements.length; j++) {
+					var el = elements[j];
+					if (el.outerHTML.endsWith("/>")) {
+						var expanded = doc.createElement(el.tagName);
+						for (var attr of el.attributes) {
+							expanded.setAttribute(attr.name, attr.value);
+						}
+						el.replaceWith(expanded);
+					}
+				}
+
+				value = doc.body.innerHTML;
 
 				try {
 					for (; i < l; i++ ) {


### PR DESCRIPTION
Potential fix for [https://github.com/Carnage-Joker/pink_book/security/code-scanning/5](https://github.com/Carnage-Joker/pink_book/security/code-scanning/5)

To fix the issue, we need to ensure that the transformation of self-closing HTML tags does not introduce vulnerabilities. Instead of using a regular expression to expand self-closing tags, we should rely on a safer approach, such as using a DOM parser to handle the transformation. This avoids the pitfalls of regular expressions and ensures that the input is treated as valid HTML.

The fix involves replacing the `value.replace(rxhtmlTag, "<$1></$2>")` logic with a DOM-based approach. Specifically:
1. Parse the `value` string into a DOM structure.
2. Identify and expand self-closing tags programmatically.
3. Serialize the DOM back into a string.

This approach ensures that the transformation is safe and does not inadvertently modify attribute values or introduce XSS vulnerabilities.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Use DOMParser to parse and programmatically expand self-closing HTML tags instead of vulnerable regex replacement.