### PR TITLE
Potential fix for code scanning alert no. 32: Prototype-polluting function

### DIFF
--- a/staticfiles/journal/scripts/jquery-1.10.2.js
+++ b/staticfiles/journal/scripts/jquery-1.10.2.js
@@ -356,6 +356,10 @@ jQuery.extend = jQuery.fn.extend = function() {
 		if ( (options = arguments[ i ]) != null ) {
 			// Extend the base object
 			for ( name in options ) {
+				// Skip dangerous properties to prevent prototype pollution
+				if ( name === "__proto__" || name === "constructor" ) {
+					continue;
+				}
 				src = target[ name ];
 				copy = options[ name ];
 


### PR DESCRIPTION
Potential fix for [https://github.com/Carnage-Joker/pink_book/security/code-scanning/32](https://github.com/Carnage-Joker/pink_book/security/code-scanning/32)

To fix the issue, we need to add explicit checks to block dangerous property names like `__proto__` and `constructor` from being copied to the target object. This can be done by adding a condition in the loop that skips these property names. This approach ensures that the function remains secure without altering its existing functionality.

The changes should be made in the `for` loop starting at line 358, where properties are copied from `options` to `target`. Specifically, we will add a condition to skip `__proto__` and `constructor`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Prevent prototype pollution by skipping '__proto__' and 'constructor' properties when extending objects.