### PR TITLE
Potential fix for code scanning alert no. 31: Prototype-polluting function

### DIFF
--- a/static/journal/scripts/jquery-1.10.2.js
+++ b/static/journal/scripts/jquery-1.10.2.js
@@ -356,6 +356,10 @@ jQuery.extend = jQuery.fn.extend = function() {
 		if ( (options = arguments[ i ]) != null ) {
 			// Extend the base object
 			for ( name in options ) {
+				// Skip dangerous properties to prevent prototype pollution
+				if ( name === "__proto__" || name === "constructor" ) {
+					continue;
+				}
 				src = target[ name ];
 				copy = options[ name ];
 


### PR DESCRIPTION
Potential fix for [https://github.com/Carnage-Joker/pink_book/security/code-scanning/31](https://github.com/Carnage-Joker/pink_book/security/code-scanning/31)

To fix the issue, we need to add explicit checks to block dangerous property names like `__proto__` and `constructor` from being copied to the `target` object. This can be achieved by adding a condition in the loop that skips these properties. This fix ensures that the function remains safe while preserving its existing functionality.

The changes will be made in the `jQuery.extend` function, specifically in the loop starting at line 358. We will add a condition to skip `name` if it matches `__proto__` or `constructor`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Skip copying "__proto__" and "constructor" within jQuery.extend to prevent prototype pollution