### PR TITLE
Potential fix for code scanning alert no. 58: Unsafe jQuery plugin

### DIFF
--- a/staticfiles/journal/scripts/bootstrap.js
+++ b/staticfiles/journal/scripts/bootstrap.js
@@ -544,11 +544,18 @@ if (!jQuery) { throw new Error("Bootstrap requires jQuery") }
   }
 
   function validateSelector(selector) {
+    // Ensure the selector is a valid CSS selector and not malicious
+    var isValidSelector = typeof selector === 'string' && /^[a-zA-Z0-9.#\[\]=: _-]+$/.test(selector);
+    if (!isValidSelector) {
+      console.error("Invalid selector provided:", selector);
+      return null;
+    }
     try {
-      var $element = $(selector)
-      return $element.length ? $element : null
+      var $element = $(selector);
+      return $element.length ? $element : null;
     } catch (e) {
-      return null
+      console.error("Error processing selector:", selector, e);
+      return null;
     }
   }
 

--- a/staticfiles/journal/scripts/bootstrap.js
+++ b/staticfiles/journal/scripts/bootstrap.js
@@ -545,14 +545,14 @@ if (!jQuery) { throw new Error("Bootstrap requires jQuery") }
 
   function validateSelector(selector) {
     // Ensure the selector is a valid CSS selector and not malicious
-    var isValidSelector = typeof selector === 'string' && /^[a-zA-Z0-9.#\[\]=: _-]+$/.test(selector);
-    if (!isValidSelector) {
-      console.error("Invalid selector provided:", selector);
+    if (typeof selector !== 'string') {
+      console.error("Invalid selector type provided:", selector);
       return null;
     }
     try {
-      var $element = $(selector);
-      return $element.length ? $element : null;
+      // Use document.querySelector to validate the selector
+      var element = document.querySelector(selector);
+      return element ? $(element) : null;
     } catch (e) {
       console.error("Error processing selector:", selector, e);
       return null;

--- a/staticfiles/journal/scripts/bootstrap.js
+++ b/staticfiles/journal/scripts/bootstrap.js
@@ -535,15 +535,21 @@ if (!jQuery) { throw new Error("Bootstrap requires jQuery") }
     this.transitioning = null
 
     if (this.options.parent) {
-      try {
-        this.$parent = $(this.options.parent)
-        if (!this.$parent.length) throw new Error()
-      } catch (e) {
+      this.$parent = validateSelector(this.options.parent)
+      if (!this.$parent) {
         console.error("Invalid parent option provided to Collapse plugin:", this.options.parent)
-        this.$parent = null
       }
     }
     if (this.options.toggle) this.toggle()
+  }
+
+  function validateSelector(selector) {
+    try {
+      var $element = $(selector)
+      return $element.length ? $element : null
+    } catch (e) {
+      return null
+    }
   }
 
   Collapse.DEFAULTS = {


### PR DESCRIPTION
Potential fix for [https://github.com/Carnage-Joker/pink_book/security/code-scanning/58](https://github.com/Carnage-Joker/pink_book/security/code-scanning/58)

To fix the issue, we need to ensure that the `this.options.parent` value is sanitized before being used in a jQuery selector. Specifically:
1. Validate that `this.options.parent` is a valid CSS selector or DOM element.
2. Reject or sanitize any input that could be interpreted as HTML or lead to XSS vulnerabilities.
3. Update the `Collapse` plugin to include this validation step before using `this.options.parent`.

The best approach is to use a utility function to validate the input and ensure it is safe to use in a jQuery selector. This function can be added to the `Collapse` plugin and invoked before assigning `this.$parent`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Add validation for the Collapse plugin’s parent option to ensure only valid selectors are passed to jQuery and prevent potential XSS.

Bug Fixes:
- Fix unsafe jQuery selector usage in Collapse plugin by validating the parent option before selection.

Enhancements:
- Introduce a validateSelector helper to verify CSS selectors or DOM elements and return null on invalid input.