### PR TITLE
Potential fix for code scanning alert no. 30: DOM text reinterpreted as HTML

### DIFF
--- a/templates/dressup/customize_avatar.html
+++ b/templates/dressup/customize_avatar.html
@@ -194,9 +194,16 @@
         if (!selector) return;
 
         const newValue = selector.value;
-        const layerImg = document.getElementById('preview-' + layer);
         
-        layerImg.src = "{% static 'dressup/avatars/' %}" + layer + "/" + newValue + ".png";
+        // Validate newValue to ensure it contains only alphanumeric characters, dashes, or underscores
+        const sanitizedValue = /^[a-zA-Z0-9_-]+$/.test(newValue) ? newValue : '';
+        if (!sanitizedValue) {
+            console.warn(`Invalid value for layer "${layer}":`, newValue);
+            return;
+        }
+
+        const layerImg = document.getElementById('preview-' + layer);
+        layerImg.src = "{% static 'dressup/avatars/' %}" + layer + "/" + sanitizedValue + ".png";
     }
 
     function attachEventListeners() {


### PR DESCRIPTION
Potential fix for [https://github.com/Carnage-Joker/pink_book/security/code-scanning/30](https://github.com/Carnage-Joker/pink_book/security/code-scanning/30)

To fix the issue, we need to sanitize the `selector.value` before using it in the `src` attribute of the `<img>` tag. This can be achieved by validating the input against a whitelist of allowed values or by escaping any potentially dangerous characters. Since the `layer` values are likely predefined (e.g., "top", "skirt"), we can use a whitelist approach to ensure only valid values are used.

The fix involves:
1. Adding a validation step to ensure `newValue` contains only allowed characters or matches a predefined list of valid options.
2. Updating the `updateSingleLayer` function to include this validation before constructing the `src` URL.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Validate layer selection values against a strict whitelist regex and abort on invalid input