### PR TITLE
Potential fix for code scanning alert no. 18: DOM text reinterpreted as HTML

### DIFF
--- a/static/journal/scripts/bootstrap.js
+++ b/static/journal/scripts/bootstrap.js
@@ -1800,7 +1800,7 @@ if (!jQuery) { throw new Error("Bootstrap requires jQuery") }
 
     if (e.isDefaultPrevented()) return
 
-    var $target = $(selector)
+    var $target = $this.closest('ul:not(.dropdown-menu)').find(selector)
 
     this.activate($this.parent('li'), $ul)
     this.activate($target, $target.parent(), function () {


### PR DESCRIPTION
Potential fix for [https://github.com/Carnage-Joker/pink_book/security/code-scanning/18](https://github.com/Carnage-Joker/pink_book/security/code-scanning/18)

To fix the issue, the `selector` variable should be sanitized or validated before being passed to the `$()` function. This can be achieved by ensuring that the `data-target` attribute contains only safe values, such as valid CSS selectors, and rejecting or escaping any potentially malicious input.

The best approach is to use `$.find()` instead of `$()` for selecting elements based on `selector`. The `$.find()` function interprets its input strictly as a CSS selector and does not allow HTML interpretation, thereby mitigating the XSS risk.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Replace direct `$(selector)` calls with `$this.closest('ul:not(.dropdown-menu)').find(selector)` to prevent HTML interpretation and reduce XSS risk