### PR TITLE
Potential fix for code scanning alert no. 2: Information exposure through an exception

### DIFF
--- a/journal/views.py
+++ b/journal/views.py
@@ -807,7 +807,8 @@ def generate_task_view(request):
             task = generate_task(user)
             return JsonResponse({"task": task})
         except Exception as e:
-            return JsonResponse({"error": str(e)}, status=500)
+            logger.error("Error occurred while generating task", exc_info=True)
+            return JsonResponse({"error": "An internal error occurred."}, status=500)
     return JsonResponse({"error": "Invalid request method"}, status=400)
 
 


### PR DESCRIPTION
Potential fix for [https://github.com/Carnage-Joker/pink_book/security/code-scanning/2](https://github.com/Carnage-Joker/pink_book/security/code-scanning/2)

To fix the issue, the code should log the exception details internally using the `logging` module and return a generic error message to the user. This ensures that sensitive information is not exposed while still allowing developers to debug the issue using the logs.

Steps to implement the fix:
1. Use the `logger` object to log the exception details, including the stack trace, for internal debugging purposes.
2. Replace the exposed exception message (`str(e)`) in the JSON response with a generic error message, such as `"An internal error occurred."`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Log exception details with stack trace using logger.error and return a generic 'An internal error occurred.' message instead of the raw exception.