### PR TITLE
Potential fix for code scanning alert no. 11: DOM text reinterpreted as HTML

### DIFF
--- a/static/journal/scripts/bootstrap.js
+++ b/static/journal/scripts/bootstrap.js
@@ -116,7 +116,7 @@ if (!jQuery) { throw new Error("Bootstrap requires jQuery") }
       selector = selector && selector.replace(/.*(?=#[^\s]*$)/, '') // strip for ie7
     }
 
-    var $parent = $(selector)
+    var $parent = $.find(selector)
 
     if (e) e.preventDefault()
 


### PR DESCRIPTION
Potential fix for [https://github.com/Carnage-Joker/pink_book/security/code-scanning/11](https://github.com/Carnage-Joker/pink_book/security/code-scanning/11)

To fix the issue, the `selector` variable should be sanitized or validated before being used in `$(selector)`. This can be achieved by ensuring that `selector` is treated strictly as a CSS selector and not as HTML. Using `$.find(selector)` instead of `$(selector)` is a safer alternative, as it prevents the interpretation of `selector` as HTML.

**Steps to fix:**
1. Replace the usage of `$(selector)` with `$.find(selector)` on line 119.
2. Ensure that the `selector` variable is validated to confirm it is a legitimate CSS selector before passing it to `$.find`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Replace use of $(selector) with $.find(selector) for safer element lookup