### PR TITLE
Potential fix for code scanning alert no. 9: Unsafe jQuery plugin

### DIFF
--- a/static/journal/scripts/bootstrap.js
+++ b/static/journal/scripts/bootstrap.js
@@ -534,7 +534,7 @@ if (!jQuery) { throw new Error("Bootstrap requires jQuery") }
     this.options       = $.extend({}, Collapse.DEFAULTS, options)
     this.transitioning = null
 
-    if (this.options.parent) this.$parent = $(this.options.parent)
+    if (this.options.parent) this.$parent = $(jQuery.find(this.options.parent))
     if (this.options.toggle) this.toggle()
   }
 


### PR DESCRIPTION
Potential fix for [https://github.com/Carnage-Joker/pink_book/security/code-scanning/9](https://github.com/Carnage-Joker/pink_book/security/code-scanning/9)

To fix the issue, the plugin should validate or sanitize the `parent` option before using it in a jQuery selector. Specifically, the `parent` option should be checked to ensure it is a valid CSS selector and not arbitrary HTML. This can be achieved by using `jQuery.find` instead of `jQuery` for selecting elements, as `jQuery.find` interprets the input strictly as a CSS selector and does not evaluate it as HTML.

The changes will be made in the `static/journal/scripts/bootstrap.js` file:
1. Modify the `Collapse` constructor to sanitize the `parent` option using `jQuery.find`.
2. Ensure that the `parent` option is safely used throughout the plugin.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Use `jQuery.find` instead of direct `$()` to sanitize the `parent` option before selection in `bootstrap.js`