### PR TITLE
Potential fix for code scanning alert no. 12: DOM text reinterpreted as HTML

### DIFF
--- a/static/journal/scripts/bootstrap.js
+++ b/static/journal/scripts/bootstrap.js
@@ -481,7 +481,12 @@ if (!jQuery) { throw new Error("Bootstrap requires jQuery") }
 
   $(document).on('click.bs.carousel.data-api', '[data-slide], [data-slide-to]', function (e) {
     var $this   = $(this), href
-    var $target = $($this.attr('data-target') || (href = $this.attr('href')) && href.replace(/.*(?=#[^\s]+$)/, '')) //strip for ie7
+    var targetSelector = $this.attr('data-target') || (href = $this.attr('href')) && href.replace(/.*(?=#[^\s]+$)/, ''); //strip for ie7
+    if (targetSelector && /^#[a-zA-Z][\w:.-]*$/.test(targetSelector)) { // Validate as a safe CSS ID selector
+      var $target = $(targetSelector);
+    } else {
+      throw new Error("Invalid target selector: " + targetSelector);
+    }
     var options = $.extend({}, $target.data(), $this.data())
     var slideIndex = $this.attr('data-slide-to')
     if (slideIndex) options.interval = false


### PR DESCRIPTION
Potential fix for [https://github.com/Carnage-Joker/pink_book/security/code-scanning/12](https://github.com/Carnage-Joker/pink_book/security/code-scanning/12)

To fix the issue, we need to ensure that the value of the `data-target` or `href` attribute is sanitized or validated before being used to construct a jQuery selector. Instead of directly passing the attribute value to `$()`, we can use a safer method like `document.querySelector` or ensure that the value is strictly interpreted as a CSS selector and not as HTML or JavaScript.

The best approach is to validate the `data-target` or `href` value to ensure it matches a safe pattern (e.g., a valid CSS selector) before using it. Alternatively, we can use `$.find()` on a known parent element to limit the scope of the selector.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
