### PR TITLE
Potential fix for code scanning alert no. 13: DOM text reinterpreted as HTML

### DIFF
--- a/static/journal/scripts/bootstrap.js
+++ b/static/journal/scripts/bootstrap.js
@@ -673,6 +673,9 @@ if (!jQuery) { throw new Error("Bootstrap requires jQuery") }
     var target  = $this.attr('data-target')
         || e.preventDefault()
         || (href = $this.attr('href')) && href.replace(/.*(?=#[^\s]+$)/, '') //strip for ie7
+    if (target) {
+        target = $.escapeSelector ? $.escapeSelector(target) : target.replace(/([!"#$%&'()*+,.\/:;<=>?@[\\\]^`{|}~])/g, '\\$1');
+    }
     var $target = $(target)
     var data    = $target.data('bs.collapse')
     var option  = data ? 'toggle' : $this.data()


### PR DESCRIPTION
Potential fix for [https://github.com/Carnage-Joker/pink_book/security/code-scanning/13](https://github.com/Carnage-Joker/pink_book/security/code-scanning/13)

To fix the issue, we need to ensure that the `data-target` attribute is sanitized or validated before being used as a jQuery selector. A safer approach is to use `$.escapeSelector` (introduced in jQuery 3.0) to escape any special characters in the `data-target` value. This ensures that the value is treated strictly as a CSS selector and not as HTML or JavaScript.

Steps to fix:
1. Use `$.escapeSelector` to sanitize the `target` variable before passing it to the jQuery selector.
2. Ensure compatibility with older versions of jQuery by checking if `$.escapeSelector` exists, and fallback to a custom escaping function if necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
