### PR TITLE
Potential fix for code scanning alert no. 29: DOM text reinterpreted as HTML

### DIFF
--- a/templates/dressup/customize_avatar.html
+++ b/templates/dressup/customize_avatar.html
@@ -194,7 +194,15 @@
         const hairColorValue = document.getElementById('hair_color').value;
         const hairImg = document.getElementById('preview-hair');
         
-        hairImg.src = "{% static 'dressup/avatars/hair/' %}" + hairValue + "/" + hairColorValue + ".png";
+        // Sanitize hairValue and hairColorValue to allow only alphanumeric characters, dashes, and underscores
+        const sanitizedHairValue = /^[a-zA-Z0-9_-]+$/.test(hairValue) ? hairValue : '';
+        const sanitizedHairColorValue = /^[a-zA-Z0-9_-]+$/.test(hairColorValue) ? hairColorValue : '';
+        if (!sanitizedHairValue || !sanitizedHairColorValue) {
+            console.warn(`Invalid values for hair or hair color: hair="${hairValue}", hair_color="${hairColorValue}"`);
+            return;
+        }
+
+        hairImg.src = "{% static 'dressup/avatars/hair/' %}" + sanitizedHairValue + "/" + sanitizedHairColorValue + ".png";
     }
 
     // Generic helper for single-attribute layers: /avatars/{layer}/{value}.png


### PR DESCRIPTION
Potential fix for [https://github.com/Carnage-Joker/pink_book/security/code-scanning/29](https://github.com/Carnage-Joker/pink_book/security/code-scanning/29)

To fix the problem, we should sanitize the values read from the DOM before using them to construct the image `src` URL. Specifically, in the `updateHair()` function, both `hairValue` and `hairColorValue` should be validated to allow only safe characters (alphanumeric, dashes, underscores), just as is done for the body and single-attribute layers. This can be done by using a regular expression to test each value and only use them if they pass validation. If either value is invalid, the function should log a warning and not update the image source.

Edit the `updateHair()` function in `templates/dressup/customize_avatar.html` (lines 192-198) to add this validation.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
